### PR TITLE
feat: complete the shiro + jwt login

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,22 @@
             <artifactId>javax.mail</artifactId>
             <version>1.6.2</version>
         </dependency>
+        <!-- Shiro_jwt -->
+        <dependency>
+            <groupId>org.apache.shiro</groupId>
+            <artifactId>shiro-spring</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>java-jwt</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>1.5.8.RELEASE</version>
+        </dependency>
 
     </dependencies>
 

--- a/scripts/mysql/0_init.sql
+++ b/scripts/mysql/0_init.sql
@@ -14,6 +14,7 @@ create table users
 	cid				varchar(20),
 	department varchar(20),
 	role			varchar(20),
+	permission      varchar(50),
     stat  int,
 	follower	bigint,
 	followed  bigint,

--- a/scripts/mysql/1_init_data.sql
+++ b/scripts/mysql/1_init_data.sql
@@ -1,5 +1,7 @@
 SET NAMES 'utf8';
-INSERT INTO users VALUES (0, 'Cat', 'Cat', 'plain', 'test@reg.com', '114514', '--', NULL, NULL, 'Witchcraft', 'role', 0, 0, 0);
+INSERT INTO users VALUES (1, 'Cat', 'Cat', 'plain', 'test@reg.com', '114514', '--', NULL, NULL, 'Witchcraft', 'role', 'view', 0, 0, 0);
+INSERT INTO users VALUES (2, 'sAdmin', 'sAdmin', 'admin', 'test@reg.com', '114514', '--', NULL, NULL, 'Witchcraft', 'admin', 'view,edit', 0, 0, 0);
+INSERT INTO users VALUES (3, 'Admin', 'Admin', 'admin', 'test@reg.com', '114514', '--', NULL, NULL, 'Witchcraft', 'role', 'view', 0, 0, 0);
 INSERT INTO questions VALUES (1, '菜市场', current_timestamp, 0, 1, 0, current_timestamp, '为什么年轻人不讲武德？');
 INSERT INTO answers VALUES (1, current_timestamp, 0, 1, current_timestamp, 666, 233, 1);
 INSERT INTO replies VALUES (1, current_timestamp, 0, 1, 1, 1024, 1212, 0);

--- a/src/main/java/com/backend/seqaq/config/JWTToken.java
+++ b/src/main/java/com/backend/seqaq/config/JWTToken.java
@@ -4,20 +4,20 @@ import org.apache.shiro.authc.AuthenticationToken;
 
 public class JWTToken implements AuthenticationToken {
 
-    // 密钥
-    private String token;
+  // 密钥
+  private String token;
 
-    public JWTToken(String token) {
-        this.token = token;
-    }
+  public JWTToken(String token) {
+    this.token = token;
+  }
 
-    @Override
-    public Object getPrincipal() {
-        return token;
-    }
+  @Override
+  public Object getPrincipal() {
+    return token;
+  }
 
-    @Override
-    public Object getCredentials() {
-        return token;
-    }
+  @Override
+  public Object getCredentials() {
+    return token;
+  }
 }

--- a/src/main/java/com/backend/seqaq/config/JWTToken.java
+++ b/src/main/java/com/backend/seqaq/config/JWTToken.java
@@ -1,0 +1,23 @@
+package com.backend.seqaq.config;
+
+import org.apache.shiro.authc.AuthenticationToken;
+
+public class JWTToken implements AuthenticationToken {
+
+    // 密钥
+    private String token;
+
+    public JWTToken(String token) {
+        this.token = token;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return token;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return token;
+    }
+}

--- a/src/main/java/com/backend/seqaq/config/JWTUtil.java
+++ b/src/main/java/com/backend/seqaq/config/JWTUtil.java
@@ -1,0 +1,67 @@
+package com.backend.seqaq.config;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Date;
+
+public class JWTUtil {
+    // 过期时间5h
+    private static final long EXPIRE_TIME = 10*24*60*60*1000;
+
+    /**
+     * 校验token是否正确
+     * @param token 密钥
+     * @param secret 用户的密码
+     * @return 是否正确
+     */
+    public static boolean verify(String token, String username, String secret) {
+        try {
+            Algorithm algorithm = Algorithm.HMAC256(secret);
+            JWTVerifier verifier = JWT.require(algorithm)
+                    .withClaim("username", username)
+                    .build();
+            DecodedJWT jwt = verifier.verify(token);
+            return true;
+        } catch (Exception exception) {
+            return false;
+        }
+    }
+
+    /**
+     * 获得token中的信息无需secret解密也能获得
+     * @return token中包含的用户名
+     */
+    public static String getUsername(String token) {
+        try {
+            DecodedJWT jwt = JWT.decode(token);
+            return jwt.getClaim("username").asString();
+        } catch (JWTDecodeException e) {
+            return null;
+        }
+    }
+
+    /**
+     * 生成签名,5h后过期
+     * @param username 用户名
+     * @param secret 用户的密码
+     * @return 加密的token
+     */
+    public static String sign(String username, String secret) {
+        try {
+            Date date = new Date(System.currentTimeMillis()+EXPIRE_TIME);
+            Algorithm algorithm = Algorithm.HMAC256(secret);
+            // 附带username信息
+            return JWT.create()
+                    .withClaim("username", username)
+                    .withExpiresAt(date)
+                    .sign(algorithm);
+        } catch (UnsupportedEncodingException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/backend/seqaq/config/JWTUtil.java
+++ b/src/main/java/com/backend/seqaq/config/JWTUtil.java
@@ -10,58 +10,56 @@ import java.io.UnsupportedEncodingException;
 import java.util.Date;
 
 public class JWTUtil {
-    // 过期时间5h
-    private static final long EXPIRE_TIME = 10*24*60*60*1000;
+  // 过期时间5h
+  private static final long EXPIRE_TIME = 10 * 24 * 60 * 60 * 1000;
 
-    /**
-     * 校验token是否正确
-     * @param token 密钥
-     * @param secret 用户的密码
-     * @return 是否正确
-     */
-    public static boolean verify(String token, String username, String secret) {
-        try {
-            Algorithm algorithm = Algorithm.HMAC256(secret);
-            JWTVerifier verifier = JWT.require(algorithm)
-                    .withClaim("username", username)
-                    .build();
-            DecodedJWT jwt = verifier.verify(token);
-            return true;
-        } catch (Exception exception) {
-            return false;
-        }
+  /**
+   * 校验token是否正确
+   *
+   * @param token 密钥
+   * @param secret 用户的密码
+   * @return 是否正确
+   */
+  public static boolean verify(String token, String username, String secret) {
+    try {
+      Algorithm algorithm = Algorithm.HMAC256(secret);
+      JWTVerifier verifier = JWT.require(algorithm).withClaim("username", username).build();
+      DecodedJWT jwt = verifier.verify(token);
+      return true;
+    } catch (Exception exception) {
+      return false;
     }
+  }
 
-    /**
-     * 获得token中的信息无需secret解密也能获得
-     * @return token中包含的用户名
-     */
-    public static String getUsername(String token) {
-        try {
-            DecodedJWT jwt = JWT.decode(token);
-            return jwt.getClaim("username").asString();
-        } catch (JWTDecodeException e) {
-            return null;
-        }
+  /**
+   * 获得token中的信息无需secret解密也能获得
+   *
+   * @return token中包含的用户名
+   */
+  public static String getUsername(String token) {
+    try {
+      DecodedJWT jwt = JWT.decode(token);
+      return jwt.getClaim("username").asString();
+    } catch (JWTDecodeException e) {
+      return null;
     }
+  }
 
-    /**
-     * 生成签名,5h后过期
-     * @param username 用户名
-     * @param secret 用户的密码
-     * @return 加密的token
-     */
-    public static String sign(String username, String secret) {
-        try {
-            Date date = new Date(System.currentTimeMillis()+EXPIRE_TIME);
-            Algorithm algorithm = Algorithm.HMAC256(secret);
-            // 附带username信息
-            return JWT.create()
-                    .withClaim("username", username)
-                    .withExpiresAt(date)
-                    .sign(algorithm);
-        } catch (UnsupportedEncodingException e) {
-            return null;
-        }
+  /**
+   * 生成签名,5h后过期
+   *
+   * @param username 用户名
+   * @param secret 用户的密码
+   * @return 加密的token
+   */
+  public static String sign(String username, String secret) {
+    try {
+      Date date = new Date(System.currentTimeMillis() + EXPIRE_TIME);
+      Algorithm algorithm = Algorithm.HMAC256(secret);
+      // 附带username信息
+      return JWT.create().withClaim("username", username).withExpiresAt(date).sign(algorithm);
+    } catch (UnsupportedEncodingException e) {
+      return null;
     }
+  }
 }

--- a/src/main/java/com/backend/seqaq/config/ShiroConfig.java
+++ b/src/main/java/com/backend/seqaq/config/ShiroConfig.java
@@ -1,0 +1,91 @@
+package com.backend.seqaq.config;
+
+import com.backend.seqaq.filter.JWTFilter;
+import com.backend.seqaq.realm.MyRealm;
+import org.apache.shiro.mgt.DefaultSessionStorageEvaluator;
+import org.apache.shiro.mgt.DefaultSubjectDAO;
+import org.apache.shiro.spring.LifecycleBeanPostProcessor;
+import org.apache.shiro.spring.security.interceptor.AuthorizationAttributeSourceAdvisor;
+import org.apache.shiro.spring.web.ShiroFilterFactoryBean;
+import org.apache.shiro.web.mgt.DefaultWebSecurityManager;
+import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+
+import javax.servlet.Filter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class ShiroConfig {
+    @Bean("securityManager")
+    public DefaultWebSecurityManager getManager(MyRealm realm) {
+        DefaultWebSecurityManager manager = new DefaultWebSecurityManager();
+        // 使用自己的realm
+        manager.setRealm(realm);
+
+        /*
+         * 关闭shiro自带的session，详情见文档
+         * http://shiro.apache.org/session-management.html#SessionManagement-StatelessApplications%28Sessionless%29
+         */
+        DefaultSubjectDAO subjectDAO = new DefaultSubjectDAO();
+        DefaultSessionStorageEvaluator defaultSessionStorageEvaluator = new DefaultSessionStorageEvaluator();
+        defaultSessionStorageEvaluator.setSessionStorageEnabled(false);
+        subjectDAO.setSessionStorageEvaluator(defaultSessionStorageEvaluator);
+        manager.setSubjectDAO(subjectDAO);
+
+        return manager;
+    }
+
+    @Bean("shiroFilter")
+    public ShiroFilterFactoryBean factory(DefaultWebSecurityManager securityManager) {
+        ShiroFilterFactoryBean factoryBean = new ShiroFilterFactoryBean();
+
+        // 添加自己的过滤器并且取名为jwt
+        Map<String, Filter> filterMap = new HashMap<>();
+        filterMap.put("jwt", new JWTFilter());
+        factoryBean.setFilters(filterMap);
+
+        factoryBean.setSecurityManager(securityManager);
+        factoryBean.setUnauthorizedUrl("/401");
+
+        /*
+         * 自定义url规则
+         * http://shiro.apache.org/web.html#urls-
+         */
+        Map<String, String> filterRuleMap = new HashMap<>();
+        // 所有请求通过我们自己的JWT Filter
+        filterRuleMap.put("/**", "jwt");
+        // 访问401和404页面不通过我们的Filter
+        filterRuleMap.put("/401", "anon");
+        factoryBean.setFilterChainDefinitionMap(filterRuleMap);
+        return factoryBean;
+    }
+
+    /**
+     * 下面的代码是添加注解支持
+     */
+    @Bean
+    @DependsOn("lifecycleBeanPostProcessor")
+    public DefaultAdvisorAutoProxyCreator defaultAdvisorAutoProxyCreator() {
+        DefaultAdvisorAutoProxyCreator defaultAdvisorAutoProxyCreator = new DefaultAdvisorAutoProxyCreator();
+        // 强制使用cglib，防止重复代理和可能引起代理出错的问题
+        // https://zhuanlan.zhihu.com/p/29161098
+        defaultAdvisorAutoProxyCreator.setProxyTargetClass(true);
+        return defaultAdvisorAutoProxyCreator;
+    }
+
+    @Bean
+    public LifecycleBeanPostProcessor lifecycleBeanPostProcessor() {
+        return new LifecycleBeanPostProcessor();
+    }
+
+    @Bean
+    public AuthorizationAttributeSourceAdvisor authorizationAttributeSourceAdvisor(DefaultWebSecurityManager securityManager) {
+        AuthorizationAttributeSourceAdvisor advisor = new AuthorizationAttributeSourceAdvisor();
+        advisor.setSecurityManager(securityManager);
+        return advisor;
+    }
+}

--- a/src/main/java/com/backend/seqaq/config/ShiroConfig.java
+++ b/src/main/java/com/backend/seqaq/config/ShiroConfig.java
@@ -20,72 +20,73 @@ import java.util.Map;
 
 @Configuration
 public class ShiroConfig {
-    @Bean("securityManager")
-    public DefaultWebSecurityManager getManager(MyRealm realm) {
-        DefaultWebSecurityManager manager = new DefaultWebSecurityManager();
-        // 使用自己的realm
-        manager.setRealm(realm);
+  @Bean("securityManager")
+  public DefaultWebSecurityManager getManager(MyRealm realm) {
+    DefaultWebSecurityManager manager = new DefaultWebSecurityManager();
+    // 使用自己的realm
+    manager.setRealm(realm);
 
-        /*
-         * 关闭shiro自带的session，详情见文档
-         * http://shiro.apache.org/session-management.html#SessionManagement-StatelessApplications%28Sessionless%29
-         */
-        DefaultSubjectDAO subjectDAO = new DefaultSubjectDAO();
-        DefaultSessionStorageEvaluator defaultSessionStorageEvaluator = new DefaultSessionStorageEvaluator();
-        defaultSessionStorageEvaluator.setSessionStorageEnabled(false);
-        subjectDAO.setSessionStorageEvaluator(defaultSessionStorageEvaluator);
-        manager.setSubjectDAO(subjectDAO);
-
-        return manager;
-    }
-
-    @Bean("shiroFilter")
-    public ShiroFilterFactoryBean factory(DefaultWebSecurityManager securityManager) {
-        ShiroFilterFactoryBean factoryBean = new ShiroFilterFactoryBean();
-
-        // 添加自己的过滤器并且取名为jwt
-        Map<String, Filter> filterMap = new HashMap<>();
-        filterMap.put("jwt", new JWTFilter());
-        factoryBean.setFilters(filterMap);
-
-        factoryBean.setSecurityManager(securityManager);
-        factoryBean.setUnauthorizedUrl("/401");
-
-        /*
-         * 自定义url规则
-         * http://shiro.apache.org/web.html#urls-
-         */
-        Map<String, String> filterRuleMap = new HashMap<>();
-        // 所有请求通过我们自己的JWT Filter
-        filterRuleMap.put("/**", "jwt");
-        // 访问401和404页面不通过我们的Filter
-        filterRuleMap.put("/401", "anon");
-        factoryBean.setFilterChainDefinitionMap(filterRuleMap);
-        return factoryBean;
-    }
-
-    /**
-     * 下面的代码是添加注解支持
+    /*
+     * 关闭shiro自带的session，详情见文档
+     * http://shiro.apache.org/session-management.html#SessionManagement-StatelessApplications%28Sessionless%29
      */
-    @Bean
-    @DependsOn("lifecycleBeanPostProcessor")
-    public DefaultAdvisorAutoProxyCreator defaultAdvisorAutoProxyCreator() {
-        DefaultAdvisorAutoProxyCreator defaultAdvisorAutoProxyCreator = new DefaultAdvisorAutoProxyCreator();
-        // 强制使用cglib，防止重复代理和可能引起代理出错的问题
-        // https://zhuanlan.zhihu.com/p/29161098
-        defaultAdvisorAutoProxyCreator.setProxyTargetClass(true);
-        return defaultAdvisorAutoProxyCreator;
-    }
+    DefaultSubjectDAO subjectDAO = new DefaultSubjectDAO();
+    DefaultSessionStorageEvaluator defaultSessionStorageEvaluator =
+        new DefaultSessionStorageEvaluator();
+    defaultSessionStorageEvaluator.setSessionStorageEnabled(false);
+    subjectDAO.setSessionStorageEvaluator(defaultSessionStorageEvaluator);
+    manager.setSubjectDAO(subjectDAO);
 
-    @Bean
-    public LifecycleBeanPostProcessor lifecycleBeanPostProcessor() {
-        return new LifecycleBeanPostProcessor();
-    }
+    return manager;
+  }
 
-    @Bean
-    public AuthorizationAttributeSourceAdvisor authorizationAttributeSourceAdvisor(DefaultWebSecurityManager securityManager) {
-        AuthorizationAttributeSourceAdvisor advisor = new AuthorizationAttributeSourceAdvisor();
-        advisor.setSecurityManager(securityManager);
-        return advisor;
-    }
+  @Bean("shiroFilter")
+  public ShiroFilterFactoryBean factory(DefaultWebSecurityManager securityManager) {
+    ShiroFilterFactoryBean factoryBean = new ShiroFilterFactoryBean();
+
+    // 添加自己的过滤器并且取名为jwt
+    Map<String, Filter> filterMap = new HashMap<>();
+    filterMap.put("jwt", new JWTFilter());
+    factoryBean.setFilters(filterMap);
+
+    factoryBean.setSecurityManager(securityManager);
+    factoryBean.setUnauthorizedUrl("/401");
+
+    /*
+     * 自定义url规则
+     * http://shiro.apache.org/web.html#urls-
+     */
+    Map<String, String> filterRuleMap = new HashMap<>();
+    // 所有请求通过我们自己的JWT Filter
+    filterRuleMap.put("/**", "jwt");
+    // 访问401和404页面不通过我们的Filter
+    filterRuleMap.put("/401", "anon");
+    factoryBean.setFilterChainDefinitionMap(filterRuleMap);
+    return factoryBean;
+  }
+
+  /** 下面的代码是添加注解支持 */
+  @Bean
+  @DependsOn("lifecycleBeanPostProcessor")
+  public DefaultAdvisorAutoProxyCreator defaultAdvisorAutoProxyCreator() {
+    DefaultAdvisorAutoProxyCreator defaultAdvisorAutoProxyCreator =
+        new DefaultAdvisorAutoProxyCreator();
+    // 强制使用cglib，防止重复代理和可能引起代理出错的问题
+    // https://zhuanlan.zhihu.com/p/29161098
+    defaultAdvisorAutoProxyCreator.setProxyTargetClass(true);
+    return defaultAdvisorAutoProxyCreator;
+  }
+
+  @Bean
+  public LifecycleBeanPostProcessor lifecycleBeanPostProcessor() {
+    return new LifecycleBeanPostProcessor();
+  }
+
+  @Bean
+  public AuthorizationAttributeSourceAdvisor authorizationAttributeSourceAdvisor(
+      DefaultWebSecurityManager securityManager) {
+    AuthorizationAttributeSourceAdvisor advisor = new AuthorizationAttributeSourceAdvisor();
+    advisor.setSecurityManager(securityManager);
+    return advisor;
+  }
 }

--- a/src/main/java/com/backend/seqaq/config/UnauthorizedException.java
+++ b/src/main/java/com/backend/seqaq/config/UnauthorizedException.java
@@ -1,0 +1,11 @@
+package com.backend.seqaq.config;
+
+public class UnauthorizedException extends RuntimeException{
+    public UnauthorizedException(String msg) {
+        super(msg);
+    }
+
+    public UnauthorizedException() {
+        super();
+    }
+}

--- a/src/main/java/com/backend/seqaq/config/UnauthorizedException.java
+++ b/src/main/java/com/backend/seqaq/config/UnauthorizedException.java
@@ -1,11 +1,11 @@
 package com.backend.seqaq.config;
 
-public class UnauthorizedException extends RuntimeException{
-    public UnauthorizedException(String msg) {
-        super(msg);
-    }
+public class UnauthorizedException extends RuntimeException {
+  public UnauthorizedException(String msg) {
+    super(msg);
+  }
 
-    public UnauthorizedException() {
-        super();
-    }
+  public UnauthorizedException() {
+    super();
+  }
 }

--- a/src/main/java/com/backend/seqaq/controller/AnswersController.java
+++ b/src/main/java/com/backend/seqaq/controller/AnswersController.java
@@ -5,6 +5,8 @@ import com.backend.seqaq.entity.Answers;
 import com.backend.seqaq.service.AnswersService;
 import com.backend.seqaq.util.Message;
 import io.swagger.annotations.Api;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresRoles;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,6 +36,7 @@ public class AnswersController {
   }
 
   @PostMapping("/addAnswer")
+  @RequiresAuthentication
   public String addAnswer(@RequestBody JSONObject jsonObject) {
     Long uid = jsonObject.getLong("uid");
     Long qid = jsonObject.getLong("qid");
@@ -42,6 +45,7 @@ public class AnswersController {
   }
 
   @PostMapping("/editAnswer")
+  @RequiresAuthentication
   public String editAnswer(@RequestBody JSONObject jsonObject) {
     String text = jsonObject.getString("text");
     Long aid = jsonObject.getLong("aid");
@@ -49,26 +53,31 @@ public class AnswersController {
   }
 
   @PostMapping("/ban")
+  @RequiresRoles("admin")
   public String ban(@RequestParam("aid") Long aid) {
     return answersService.banAnswers(aid);
   }
 
   @PostMapping("/unban")
+  @RequiresRoles("admin")
   public String unban(@RequestParam("aid") Long aid) {
     return answersService.unbanAnswers(aid);
   }
 
   @PostMapping("/delete")
+  @RequiresAuthentication
   public String delete(@RequestParam("aid") Long aid) {
     return answersService.deleteAnswers(aid);
   }
 
   @PostMapping("/dislike")
+  @RequiresAuthentication
   public String dislike(@RequestParam("aid") Long aid) {
     return answersService.dislikeAnswers(aid);
   }
 
   @PostMapping("/like")
+  @RequiresAuthentication
   public String like(@RequestParam("aid") Long aid) {
     return answersService.likeAnswers(aid);
   }

--- a/src/main/java/com/backend/seqaq/controller/ExceptionController.java
+++ b/src/main/java/com/backend/seqaq/controller/ExceptionController.java
@@ -1,0 +1,44 @@
+package com.backend.seqaq.controller;
+
+import com.backend.seqaq.config.UnauthorizedException;
+import com.backend.seqaq.entity.ResponseBean;
+import org.apache.shiro.ShiroException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestControllerAdvice
+public class ExceptionController {
+
+    // 捕捉shiro的异常
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(ShiroException.class)
+    public ResponseBean handle401(ShiroException e) {
+        return new ResponseBean(401, e.getMessage(), null);
+    }
+
+    // 捕捉UnauthorizedException
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseBean handle401() {
+        return new ResponseBean(401, "Unauthorized", null);
+    }
+
+    // 捕捉其他所有异常
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseBean globalException(HttpServletRequest request, Throwable ex) {
+        return new ResponseBean(getStatus(request).value(), ex.getMessage(), null);
+    }
+
+    private HttpStatus getStatus(HttpServletRequest request) {
+        Integer statusCode = (Integer) request.getAttribute("javax.servlet.error.status_code");
+        if (statusCode == null) {
+            return HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        return HttpStatus.valueOf(statusCode);
+    }
+}

--- a/src/main/java/com/backend/seqaq/controller/ExceptionController.java
+++ b/src/main/java/com/backend/seqaq/controller/ExceptionController.java
@@ -13,32 +13,32 @@ import javax.servlet.http.HttpServletRequest;
 @RestControllerAdvice
 public class ExceptionController {
 
-    // 捕捉shiro的异常
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(ShiroException.class)
-    public ResponseBean handle401(ShiroException e) {
-        return new ResponseBean(401, e.getMessage(), null);
-    }
+  // 捕捉shiro的异常
+  @ResponseStatus(HttpStatus.UNAUTHORIZED)
+  @ExceptionHandler(ShiroException.class)
+  public ResponseBean handle401(ShiroException e) {
+    return new ResponseBean(401, e.getMessage(), null);
+  }
 
-    // 捕捉UnauthorizedException
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(UnauthorizedException.class)
-    public ResponseBean handle401() {
-        return new ResponseBean(401, "Unauthorized", null);
-    }
+  // 捕捉UnauthorizedException
+  @ResponseStatus(HttpStatus.UNAUTHORIZED)
+  @ExceptionHandler(UnauthorizedException.class)
+  public ResponseBean handle401() {
+    return new ResponseBean(401, "Unauthorized", null);
+  }
 
-    // 捕捉其他所有异常
-    @ExceptionHandler(Exception.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ResponseBean globalException(HttpServletRequest request, Throwable ex) {
-        return new ResponseBean(getStatus(request).value(), ex.getMessage(), null);
-    }
+  // 捕捉其他所有异常
+  @ExceptionHandler(Exception.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ResponseBean globalException(HttpServletRequest request, Throwable ex) {
+    return new ResponseBean(getStatus(request).value(), ex.getMessage(), null);
+  }
 
-    private HttpStatus getStatus(HttpServletRequest request) {
-        Integer statusCode = (Integer) request.getAttribute("javax.servlet.error.status_code");
-        if (statusCode == null) {
-            return HttpStatus.INTERNAL_SERVER_ERROR;
-        }
-        return HttpStatus.valueOf(statusCode);
+  private HttpStatus getStatus(HttpServletRequest request) {
+    Integer statusCode = (Integer) request.getAttribute("javax.servlet.error.status_code");
+    if (statusCode == null) {
+      return HttpStatus.INTERNAL_SERVER_ERROR;
     }
+    return HttpStatus.valueOf(statusCode);
+  }
 }

--- a/src/main/java/com/backend/seqaq/controller/FollowersController.java
+++ b/src/main/java/com/backend/seqaq/controller/FollowersController.java
@@ -3,6 +3,7 @@ package com.backend.seqaq.controller;
 import com.backend.seqaq.entity.Followers;
 import com.backend.seqaq.service.FollowersService;
 import io.swagger.annotations.Api;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,22 +18,26 @@ public class FollowersController {
 
   // 查找关注的人
   @GetMapping("/findFollowed")
+  @RequiresAuthentication
   public List<Followers> findFollowedByUid(@RequestParam("uid") Long uid) {
     return followersService.findAllFollowedByUid(uid);
   }
 
   // 查找粉丝
   @GetMapping("/findFans")
+  @RequiresAuthentication
   public List<Followers> findFansByUid(@RequestParam("uid") Long uid) {
     return followersService.findAllFollowerByUid(uid);
   }
 
   @PostMapping("/followSomeone")
+  @RequiresAuthentication
   public String follow(@RequestParam("uid1") Long uid1, @RequestParam("uid2") Long uid2) {
     return followersService.addFollow(uid1, uid2);
   }
 
   @PostMapping("/unfollowSomeone")
+  @RequiresAuthentication
   public String unfollow(@RequestParam("uid1") Long uid1, @RequestParam("uid2") Long uid2) {
     return followersService.delFollow(uid1, uid2);
   }

--- a/src/main/java/com/backend/seqaq/controller/QueryController.java
+++ b/src/main/java/com/backend/seqaq/controller/QueryController.java
@@ -4,6 +4,10 @@ import com.backend.seqaq.entity.Questions;
 import com.backend.seqaq.entity.Users;
 import com.backend.seqaq.service.QueryService;
 import io.swagger.annotations.Api;
+import org.apache.shiro.authz.annotation.Logical;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
+import org.apache.shiro.authz.annotation.RequiresRoles;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,16 +21,19 @@ public class QueryController {
   @Autowired private QueryService queryService;
 
   @GetMapping("/users")
+  @RequiresPermissions(logical = Logical.AND, value = {"view", "edit"})
   public List<Users> queryForUsers(@RequestParam("nickname") String nickname) {
     return queryService.queryForUsers(nickname);
   }
 
   @GetMapping("/ques/tag")
+  @RequiresAuthentication
   public List<Questions> queryForQuesByTag(@RequestParam("tag") String tag) {
     return queryService.queryForQuesByTag(tag);
   }
 
   @GetMapping("/ques/title")
+  @RequiresRoles("admin")
   public List<Questions> queryForQuesByTitle(@RequestParam("title") String title) {
     return queryService.queryForQuesByTitle(title);
   }

--- a/src/main/java/com/backend/seqaq/controller/QueryController.java
+++ b/src/main/java/com/backend/seqaq/controller/QueryController.java
@@ -4,10 +4,7 @@ import com.backend.seqaq.entity.Questions;
 import com.backend.seqaq.entity.Users;
 import com.backend.seqaq.service.QueryService;
 import io.swagger.annotations.Api;
-import org.apache.shiro.authz.annotation.Logical;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
-import org.apache.shiro.authz.annotation.RequiresPermissions;
-import org.apache.shiro.authz.annotation.RequiresRoles;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/backend/seqaq/controller/QueryController.java
+++ b/src/main/java/com/backend/seqaq/controller/QueryController.java
@@ -21,7 +21,9 @@ public class QueryController {
   @Autowired private QueryService queryService;
 
   @GetMapping("/users")
-  @RequiresPermissions(logical = Logical.AND, value = {"view", "edit"})
+  @RequiresPermissions(
+      logical = Logical.AND,
+      value = {"view", "edit"})
   public List<Users> queryForUsers(@RequestParam("nickname") String nickname) {
     return queryService.queryForUsers(nickname);
   }

--- a/src/main/java/com/backend/seqaq/controller/QueryController.java
+++ b/src/main/java/com/backend/seqaq/controller/QueryController.java
@@ -21,7 +21,6 @@ public class QueryController {
   @Autowired private QueryService queryService;
 
   @GetMapping("/users")
-  @RequiresPermissions(logical = Logical.AND, value = {"view", "edit"})
   public List<Users> queryForUsers(@RequestParam("nickname") String nickname) {
     return queryService.queryForUsers(nickname);
   }
@@ -33,7 +32,6 @@ public class QueryController {
   }
 
   @GetMapping("/ques/title")
-  @RequiresRoles("admin")
   public List<Questions> queryForQuesByTitle(@RequestParam("title") String title) {
     return queryService.queryForQuesByTitle(title);
   }

--- a/src/main/java/com/backend/seqaq/controller/QuesController.java
+++ b/src/main/java/com/backend/seqaq/controller/QuesController.java
@@ -4,6 +4,8 @@ import com.alibaba.fastjson.JSONObject;
 import com.backend.seqaq.entity.Questions;
 import com.backend.seqaq.service.QuesService;
 import io.swagger.annotations.Api;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresRoles;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,6 +32,7 @@ public class QuesController {
   }
 
   @PostMapping("/createQues")
+  @RequiresAuthentication
   public void create(@RequestBody JSONObject jsonObject) {
     String title = jsonObject.getString("title");
     String tag = jsonObject.getString("tag");
@@ -38,27 +41,32 @@ public class QuesController {
   }
 
   @PostMapping("/new")
+  @RequiresAuthentication
   public String createWithDetails(@RequestBody JSONObject test) {
     System.out.println(test);
     return quesService.createQuestion(test);
   }
 
   @PostMapping("/editQues")
+  @RequiresAuthentication
   public void edit(@RequestParam("qid") Long qid, @RequestParam("text") String text) {
     quesService.editQues(qid, text);
   }
 
   @PostMapping("/banQues")
+  @RequiresRoles("admin")
   public void ban(@RequestParam("qid") Long qid) {
     quesService.banQues(qid);
   }
 
   @PostMapping("/unbanQues")
+  @RequiresRoles("admin")
   public void unban(@RequestParam("qid") Long qid) {
     quesService.unbanQues(qid);
   }
 
   @PostMapping("/delQues")
+  @RequiresAuthentication
   public void del(@RequestParam("qid") Long qid) {
     quesService.delQues(qid);
   }

--- a/src/main/java/com/backend/seqaq/controller/RepliesController.java
+++ b/src/main/java/com/backend/seqaq/controller/RepliesController.java
@@ -5,6 +5,7 @@ import com.alibaba.fastjson.JSONObject;
 import com.backend.seqaq.entity.Replies;
 import com.backend.seqaq.service.RepliesService;
 import io.swagger.annotations.Api;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -33,6 +34,7 @@ public class RepliesController {
   }
 
   @PostMapping("/replyForAnswer")
+  @RequiresAuthentication
   public String replyForAnswer(@RequestBody JSONObject jsonObject) {
     Long uid = jsonObject.getLong("uid");
     Long did = jsonObject.getLong("did");
@@ -41,6 +43,7 @@ public class RepliesController {
   }
 
   @PostMapping("/replyForReply")
+  @RequiresAuthentication
   public String replyForReply(@RequestBody JSONObject jsonObject) {
     Long uid = jsonObject.getLong("uid");
     Long did = jsonObject.getLong("did");
@@ -49,11 +52,13 @@ public class RepliesController {
   }
 
   @PostMapping("/dislike")
+  @RequiresAuthentication
   public String dislike(@RequestParam("rid") Long rid) {
     return repliesService.dislikeReplies(rid);
   }
 
   @PostMapping("/like")
+  @RequiresAuthentication
   public String like(@RequestParam("rid") Long rid) {
     return repliesService.likeReplies(rid);
   }

--- a/src/main/java/com/backend/seqaq/controller/UFQController.java
+++ b/src/main/java/com/backend/seqaq/controller/UFQController.java
@@ -3,6 +3,7 @@ package com.backend.seqaq.controller;
 import com.backend.seqaq.entity.UserAndQues;
 import com.backend.seqaq.service.UserAndQuesService;
 import io.swagger.annotations.Api;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,11 +28,13 @@ public class UFQController {
   }
 
   @PostMapping("/followSomeQues")
+  @RequiresAuthentication
   public String follow(@RequestParam("uid") Long uid, @RequestParam("qid") Long qid) {
     return userAndQuesService.addFollow(uid, qid);
   }
 
   @PostMapping("/unfollowSomeQues")
+  @RequiresAuthentication
   public String unfollow(@RequestParam("uid") Long uid, @RequestParam("qid") Long qid) {
     return userAndQuesService.delFollow(uid, qid);
   }

--- a/src/main/java/com/backend/seqaq/controller/UsersController.java
+++ b/src/main/java/com/backend/seqaq/controller/UsersController.java
@@ -69,8 +69,8 @@ public class UsersController {
   }
 
   @PostMapping("/login")
-  public ResponseBean login(@RequestParam("username") String username,
-                            @RequestParam("password") String password) {
+  public ResponseBean login(
+      @RequestParam("username") String username, @RequestParam("password") String password) {
     UserBean userBean = usersService.getUser(username);
     if (userBean.getPassword().equals(password)) {
       return new ResponseBean(200, "Login success", JWTUtil.sign(username, password));
@@ -78,10 +78,10 @@ public class UsersController {
       throw new UnauthorizedException();
     }
   }
-//  public String login(
-//      @RequestParam("account") String account, @RequestParam("password") String password) {
-//    return usersService.login(account, password);
-//  }
+  //  public String login(
+  //      @RequestParam("account") String account, @RequestParam("password") String password) {
+  //    return usersService.login(account, password);
+  //  }
 
   @PostMapping("/checkstatus")
   public String checkstatus(@RequestParam("account") String account) {

--- a/src/main/java/com/backend/seqaq/controller/UsersController.java
+++ b/src/main/java/com/backend/seqaq/controller/UsersController.java
@@ -12,6 +12,7 @@ import com.backend.seqaq.service.UsersService;
 import com.backend.seqaq.util.Message;
 import com.backend.seqaq.util.exception.RegistrationException;
 import io.swagger.annotations.Api;
+import org.apache.shiro.authz.annotation.RequiresRoles;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -48,11 +49,13 @@ public class UsersController {
   }
 
   @PostMapping("/ban")
+  @RequiresRoles("admin")
   public String ban(@RequestParam("uid") Long uid) {
     return usersService.banUser(uid);
   }
 
   @PostMapping("/unban")
+  @RequiresRoles("admin")
   public String unban(@RequestParam("uid") Long uid) {
     return usersService.unbanUser(uid);
   }

--- a/src/main/java/com/backend/seqaq/entity/ResponseBean.java
+++ b/src/main/java/com/backend/seqaq/entity/ResponseBean.java
@@ -1,0 +1,43 @@
+package com.backend.seqaq.entity;
+
+public class ResponseBean {
+
+    // http 状态码
+    private int code;
+
+    // 返回信息
+    private String msg;
+
+    // 返回的数据
+    private Object data;
+
+    public ResponseBean(int code, String msg, Object data) {
+        this.code = code;
+        this.msg = msg;
+        this.data = data;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+
+    public void setMsg(String msg) {
+        this.msg = msg;
+    }
+
+    public Object getData() {
+        return data;
+    }
+
+    public void setData(Object data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/com/backend/seqaq/entity/ResponseBean.java
+++ b/src/main/java/com/backend/seqaq/entity/ResponseBean.java
@@ -2,42 +2,42 @@ package com.backend.seqaq.entity;
 
 public class ResponseBean {
 
-    // http 状态码
-    private int code;
+  // http 状态码
+  private int code;
 
-    // 返回信息
-    private String msg;
+  // 返回信息
+  private String msg;
 
-    // 返回的数据
-    private Object data;
+  // 返回的数据
+  private Object data;
 
-    public ResponseBean(int code, String msg, Object data) {
-        this.code = code;
-        this.msg = msg;
-        this.data = data;
-    }
+  public ResponseBean(int code, String msg, Object data) {
+    this.code = code;
+    this.msg = msg;
+    this.data = data;
+  }
 
-    public int getCode() {
-        return code;
-    }
+  public int getCode() {
+    return code;
+  }
 
-    public void setCode(int code) {
-        this.code = code;
-    }
+  public void setCode(int code) {
+    this.code = code;
+  }
 
-    public String getMsg() {
-        return msg;
-    }
+  public String getMsg() {
+    return msg;
+  }
 
-    public void setMsg(String msg) {
-        this.msg = msg;
-    }
+  public void setMsg(String msg) {
+    this.msg = msg;
+  }
 
-    public Object getData() {
-        return data;
-    }
+  public Object getData() {
+    return data;
+  }
 
-    public void setData(Object data) {
-        this.data = data;
-    }
+  public void setData(Object data) {
+    this.data = data;
+  }
 }

--- a/src/main/java/com/backend/seqaq/entity/UserBean.java
+++ b/src/main/java/com/backend/seqaq/entity/UserBean.java
@@ -1,43 +1,43 @@
 package com.backend.seqaq.entity;
 
 public class UserBean {
-    private String username;
+  private String username;
 
-    private String password;
+  private String password;
 
-    private String role;
+  private String role;
 
-    private String permission;
+  private String permission;
 
-    public String getUsername() {
-        return username;
-    }
+  public String getUsername() {
+    return username;
+  }
 
-    public void setUsername(String username) {
-        this.username = username;
-    }
+  public void setUsername(String username) {
+    this.username = username;
+  }
 
-    public String getPassword() {
-        return password;
-    }
+  public String getPassword() {
+    return password;
+  }
 
-    public void setPassword(String password) {
-        this.password = password;
-    }
+  public void setPassword(String password) {
+    this.password = password;
+  }
 
-    public String getRole() {
-        return role;
-    }
+  public String getRole() {
+    return role;
+  }
 
-    public void setRole(String role) {
-        this.role = role;
-    }
+  public void setRole(String role) {
+    this.role = role;
+  }
 
-    public String getPermission() {
-        return permission;
-    }
+  public String getPermission() {
+    return permission;
+  }
 
-    public void setPermission(String permission) {
-        this.permission = permission;
-    }
+  public void setPermission(String permission) {
+    this.permission = permission;
+  }
 }

--- a/src/main/java/com/backend/seqaq/entity/UserBean.java
+++ b/src/main/java/com/backend/seqaq/entity/UserBean.java
@@ -1,0 +1,43 @@
+package com.backend.seqaq.entity;
+
+public class UserBean {
+    private String username;
+
+    private String password;
+
+    private String role;
+
+    private String permission;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public String getPermission() {
+        return permission;
+    }
+
+    public void setPermission(String permission) {
+        this.permission = permission;
+    }
+}

--- a/src/main/java/com/backend/seqaq/entity/Users.java
+++ b/src/main/java/com/backend/seqaq/entity/Users.java
@@ -44,6 +44,9 @@ public class Users {
   @Column(name = "role")
   private String role;
 
+  @Column(name = "permission")
+  private String permission;
+
   // 0: banned 1: 待激活 -1: delete 2: active
   @Column(name = "stat")
   private Integer status; // ban or not?
@@ -161,6 +164,14 @@ public class Users {
 
   public void setRole(String role) {
     this.role = role;
+  }
+
+  public String getPermission() {
+    return permission;
+  }
+
+  public void setPermission(String permission) {
+    this.permission = permission;
   }
 
   public Integer getStatus() {

--- a/src/main/java/com/backend/seqaq/filter/JWTFilter.java
+++ b/src/main/java/com/backend/seqaq/filter/JWTFilter.java
@@ -15,82 +15,75 @@ import java.io.IOException;
 
 public class JWTFilter extends BasicHttpAuthenticationFilter {
 
-    private Logger LOGGER = LoggerFactory.getLogger(this.getClass());
+  private Logger LOGGER = LoggerFactory.getLogger(this.getClass());
 
-    /**
-     * 判断用户是否想要登入。
-     * 检测header里面是否包含Authorization字段即可
-     */
-    @Override
-    protected boolean isLoginAttempt(ServletRequest request, ServletResponse response) {
-        HttpServletRequest req = (HttpServletRequest) request;
-        String authorization = req.getHeader("Authorization");
-        return authorization != null;
+  /** 判断用户是否想要登入。 检测header里面是否包含Authorization字段即可 */
+  @Override
+  protected boolean isLoginAttempt(ServletRequest request, ServletResponse response) {
+    HttpServletRequest req = (HttpServletRequest) request;
+    String authorization = req.getHeader("Authorization");
+    return authorization != null;
+  }
+
+  /** */
+  @Override
+  protected boolean executeLogin(ServletRequest request, ServletResponse response)
+      throws Exception {
+    HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+    String authorization = httpServletRequest.getHeader("Authorization");
+
+    JWTToken token = new JWTToken(authorization);
+    // 提交给realm进行登入，如果错误他会抛出异常并被捕获
+    getSubject(request, response).login(token);
+    // 如果没有抛出异常则代表登入成功，返回true
+    return true;
+  }
+
+  /**
+   * 这里我们详细说明下为什么最终返回的都是true，即允许访问 例如我们提供一个地址 GET /article 登入用户和游客看到的内容是不同的
+   * 如果在这里返回了false，请求会被直接拦截，用户看不到任何东西 所以我们在这里返回true，Controller中可以通过 subject.isAuthenticated()
+   * 来判断用户是否登入 如果有些资源只有登入用户才能访问，我们只需要在方法上面加上 @RequiresAuthentication 注解即可
+   * 但是这样做有一个缺点，就是不能够对GET,POST等请求进行分别过滤鉴权(因为我们重写了官方的方法)，但实际上对应用影响不大
+   */
+  @Override
+  protected boolean isAccessAllowed(
+      ServletRequest request, ServletResponse response, Object mappedValue) {
+    if (isLoginAttempt(request, response)) {
+      try {
+        executeLogin(request, response);
+      } catch (Exception e) {
+        response401(request, response);
+      }
     }
+    return true;
+  }
 
-    /**
-     *
-     */
-    @Override
-    protected boolean executeLogin(ServletRequest request, ServletResponse response) throws Exception {
-        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
-        String authorization = httpServletRequest.getHeader("Authorization");
-
-        JWTToken token = new JWTToken(authorization);
-        // 提交给realm进行登入，如果错误他会抛出异常并被捕获
-        getSubject(request, response).login(token);
-        // 如果没有抛出异常则代表登入成功，返回true
-        return true;
+  /** 对跨域提供支持 */
+  @Override
+  protected boolean preHandle(ServletRequest request, ServletResponse response) throws Exception {
+    HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+    HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+    httpServletResponse.setHeader(
+        "Access-control-Allow-Origin", httpServletRequest.getHeader("Origin"));
+    httpServletResponse.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS,PUT,DELETE");
+    httpServletResponse.setHeader(
+        "Access-Control-Allow-Headers",
+        httpServletRequest.getHeader("Access-Control-Request-Headers"));
+    // 跨域时会首先发送一个option请求，这里我们给option请求直接返回正常状态
+    if (httpServletRequest.getMethod().equals(RequestMethod.OPTIONS.name())) {
+      httpServletResponse.setStatus(HttpStatus.OK.value());
+      return false;
     }
+    return super.preHandle(request, response);
+  }
 
-    /**
-     * 这里我们详细说明下为什么最终返回的都是true，即允许访问
-     * 例如我们提供一个地址 GET /article
-     * 登入用户和游客看到的内容是不同的
-     * 如果在这里返回了false，请求会被直接拦截，用户看不到任何东西
-     * 所以我们在这里返回true，Controller中可以通过 subject.isAuthenticated() 来判断用户是否登入
-     * 如果有些资源只有登入用户才能访问，我们只需要在方法上面加上 @RequiresAuthentication 注解即可
-     * 但是这样做有一个缺点，就是不能够对GET,POST等请求进行分别过滤鉴权(因为我们重写了官方的方法)，但实际上对应用影响不大
-     */
-    @Override
-    protected boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue) {
-        if (isLoginAttempt(request, response)) {
-            try {
-                executeLogin(request, response);
-            } catch (Exception e) {
-                response401(request, response);
-            }
-        }
-        return true;
+  /** 将非法请求跳转到 /401 */
+  private void response401(ServletRequest req, ServletResponse resp) {
+    try {
+      HttpServletResponse httpServletResponse = (HttpServletResponse) resp;
+      httpServletResponse.sendRedirect("/401");
+    } catch (IOException e) {
+      LOGGER.error(e.getMessage());
     }
-
-    /**
-     * 对跨域提供支持
-     */
-    @Override
-    protected boolean preHandle(ServletRequest request, ServletResponse response) throws Exception {
-        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
-        HttpServletResponse httpServletResponse = (HttpServletResponse) response;
-        httpServletResponse.setHeader("Access-control-Allow-Origin", httpServletRequest.getHeader("Origin"));
-        httpServletResponse.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS,PUT,DELETE");
-        httpServletResponse.setHeader("Access-Control-Allow-Headers", httpServletRequest.getHeader("Access-Control-Request-Headers"));
-        // 跨域时会首先发送一个option请求，这里我们给option请求直接返回正常状态
-        if (httpServletRequest.getMethod().equals(RequestMethod.OPTIONS.name())) {
-            httpServletResponse.setStatus(HttpStatus.OK.value());
-            return false;
-        }
-        return super.preHandle(request, response);
-    }
-
-    /**
-     * 将非法请求跳转到 /401
-     */
-    private void response401(ServletRequest req, ServletResponse resp) {
-        try {
-            HttpServletResponse httpServletResponse = (HttpServletResponse) resp;
-            httpServletResponse.sendRedirect("/401");
-        } catch (IOException e) {
-            LOGGER.error(e.getMessage());
-        }
-    }
+  }
 }

--- a/src/main/java/com/backend/seqaq/filter/JWTFilter.java
+++ b/src/main/java/com/backend/seqaq/filter/JWTFilter.java
@@ -1,0 +1,96 @@
+package com.backend.seqaq.filter;
+
+import com.backend.seqaq.config.JWTToken;
+import org.apache.shiro.web.filter.authc.BasicHttpAuthenticationFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class JWTFilter extends BasicHttpAuthenticationFilter {
+
+    private Logger LOGGER = LoggerFactory.getLogger(this.getClass());
+
+    /**
+     * 判断用户是否想要登入。
+     * 检测header里面是否包含Authorization字段即可
+     */
+    @Override
+    protected boolean isLoginAttempt(ServletRequest request, ServletResponse response) {
+        HttpServletRequest req = (HttpServletRequest) request;
+        String authorization = req.getHeader("Authorization");
+        return authorization != null;
+    }
+
+    /**
+     *
+     */
+    @Override
+    protected boolean executeLogin(ServletRequest request, ServletResponse response) throws Exception {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        String authorization = httpServletRequest.getHeader("Authorization");
+
+        JWTToken token = new JWTToken(authorization);
+        // 提交给realm进行登入，如果错误他会抛出异常并被捕获
+        getSubject(request, response).login(token);
+        // 如果没有抛出异常则代表登入成功，返回true
+        return true;
+    }
+
+    /**
+     * 这里我们详细说明下为什么最终返回的都是true，即允许访问
+     * 例如我们提供一个地址 GET /article
+     * 登入用户和游客看到的内容是不同的
+     * 如果在这里返回了false，请求会被直接拦截，用户看不到任何东西
+     * 所以我们在这里返回true，Controller中可以通过 subject.isAuthenticated() 来判断用户是否登入
+     * 如果有些资源只有登入用户才能访问，我们只需要在方法上面加上 @RequiresAuthentication 注解即可
+     * 但是这样做有一个缺点，就是不能够对GET,POST等请求进行分别过滤鉴权(因为我们重写了官方的方法)，但实际上对应用影响不大
+     */
+    @Override
+    protected boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue) {
+        if (isLoginAttempt(request, response)) {
+            try {
+                executeLogin(request, response);
+            } catch (Exception e) {
+                response401(request, response);
+            }
+        }
+        return true;
+    }
+
+    /**
+     * 对跨域提供支持
+     */
+    @Override
+    protected boolean preHandle(ServletRequest request, ServletResponse response) throws Exception {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+        httpServletResponse.setHeader("Access-control-Allow-Origin", httpServletRequest.getHeader("Origin"));
+        httpServletResponse.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS,PUT,DELETE");
+        httpServletResponse.setHeader("Access-Control-Allow-Headers", httpServletRequest.getHeader("Access-Control-Request-Headers"));
+        // 跨域时会首先发送一个option请求，这里我们给option请求直接返回正常状态
+        if (httpServletRequest.getMethod().equals(RequestMethod.OPTIONS.name())) {
+            httpServletResponse.setStatus(HttpStatus.OK.value());
+            return false;
+        }
+        return super.preHandle(request, response);
+    }
+
+    /**
+     * 将非法请求跳转到 /401
+     */
+    private void response401(ServletRequest req, ServletResponse resp) {
+        try {
+            HttpServletResponse httpServletResponse = (HttpServletResponse) resp;
+            httpServletResponse.sendRedirect("/401");
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/backend/seqaq/realm/MyRealm.java
+++ b/src/main/java/com/backend/seqaq/realm/MyRealm.java
@@ -24,58 +24,53 @@ import java.util.Set;
 @Service
 public class MyRealm extends AuthorizingRealm {
 
-    private static final Logger LOGGER = LogManager.getLogger(MyRealm.class);
+  private static final Logger LOGGER = LogManager.getLogger(MyRealm.class);
 
-    private UsersService userService;
+  private UsersService userService;
 
-    @Autowired
-    public void setUserService(UsersService userService) {
-        this.userService = userService;
+  @Autowired
+  public void setUserService(UsersService userService) {
+    this.userService = userService;
+  }
+
+  /** 大坑！，必须重写此方法，不然Shiro会报错 */
+  @Override
+  public boolean supports(AuthenticationToken token) {
+    return token instanceof JWTToken;
+  }
+
+  /** 只有当需要检测用户权限的时候才会调用此方法，例如checkRole,checkPermission之类的 */
+  @Override
+  protected AuthorizationInfo doGetAuthorizationInfo(PrincipalCollection principals) {
+    String username = JWTUtil.getUsername(principals.toString());
+    UserBean user = userService.getUser(username);
+    SimpleAuthorizationInfo simpleAuthorizationInfo = new SimpleAuthorizationInfo();
+    simpleAuthorizationInfo.addRole(user.getRole());
+    Set<String> permission = new HashSet<>(Arrays.asList(user.getPermission().split(",")));
+    simpleAuthorizationInfo.addStringPermissions(permission);
+    return simpleAuthorizationInfo;
+  }
+
+  /** 默认使用此方法进行用户名正确与否验证，错误抛出异常即可。 */
+  @Override
+  protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken auth)
+      throws AuthenticationException {
+    String token = (String) auth.getCredentials();
+    // 解密获得username，用于和数据库进行对比
+    String username = JWTUtil.getUsername(token);
+    if (username == null) {
+      throw new AuthenticationException("token invalid");
     }
 
-    /**
-     * 大坑！，必须重写此方法，不然Shiro会报错
-     */
-    @Override
-    public boolean supports(AuthenticationToken token) {
-        return token instanceof JWTToken;
+    UserBean userBean = userService.getUser(username);
+    if (userBean == null) {
+      throw new AuthenticationException("User didn't existed!");
     }
 
-    /**
-     * 只有当需要检测用户权限的时候才会调用此方法，例如checkRole,checkPermission之类的
-     */
-    @Override
-    protected AuthorizationInfo doGetAuthorizationInfo(PrincipalCollection principals) {
-        String username = JWTUtil.getUsername(principals.toString());
-        UserBean user = userService.getUser(username);
-        SimpleAuthorizationInfo simpleAuthorizationInfo = new SimpleAuthorizationInfo();
-        simpleAuthorizationInfo.addRole(user.getRole());
-        Set<String> permission = new HashSet<>(Arrays.asList(user.getPermission().split(",")));
-        simpleAuthorizationInfo.addStringPermissions(permission);
-        return simpleAuthorizationInfo;
+    if (!JWTUtil.verify(token, username, userBean.getPassword())) {
+      throw new AuthenticationException("Username or password error");
     }
 
-    /**
-     * 默认使用此方法进行用户名正确与否验证，错误抛出异常即可。
-     */
-    @Override
-    protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken auth) throws AuthenticationException {
-        String token = (String) auth.getCredentials();
-        // 解密获得username，用于和数据库进行对比
-        String username = JWTUtil.getUsername(token);
-        if (username == null) {
-            throw new AuthenticationException("token invalid");
-        }
-
-        UserBean userBean = userService.getUser(username);
-        if (userBean == null) {
-            throw new AuthenticationException("User didn't existed!");
-        }
-
-        if (! JWTUtil.verify(token, username, userBean.getPassword())) {
-            throw new AuthenticationException("Username or password error");
-        }
-
-        return new SimpleAuthenticationInfo(token, token, "my_realm");
-    }
+    return new SimpleAuthenticationInfo(token, token, "my_realm");
+  }
 }

--- a/src/main/java/com/backend/seqaq/realm/MyRealm.java
+++ b/src/main/java/com/backend/seqaq/realm/MyRealm.java
@@ -1,0 +1,81 @@
+package com.backend.seqaq.realm;
+
+import com.backend.seqaq.config.JWTToken;
+import com.backend.seqaq.config.JWTUtil;
+import com.backend.seqaq.entity.UserBean;
+import com.backend.seqaq.service.UsersService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.SimpleAuthenticationInfo;
+import org.apache.shiro.authz.AuthorizationInfo;
+import org.apache.shiro.authz.SimpleAuthorizationInfo;
+import org.apache.shiro.realm.AuthorizingRealm;
+import org.apache.shiro.subject.PrincipalCollection;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+@Service
+public class MyRealm extends AuthorizingRealm {
+
+    private static final Logger LOGGER = LogManager.getLogger(MyRealm.class);
+
+    private UsersService userService;
+
+    @Autowired
+    public void setUserService(UsersService userService) {
+        this.userService = userService;
+    }
+
+    /**
+     * 大坑！，必须重写此方法，不然Shiro会报错
+     */
+    @Override
+    public boolean supports(AuthenticationToken token) {
+        return token instanceof JWTToken;
+    }
+
+    /**
+     * 只有当需要检测用户权限的时候才会调用此方法，例如checkRole,checkPermission之类的
+     */
+    @Override
+    protected AuthorizationInfo doGetAuthorizationInfo(PrincipalCollection principals) {
+        String username = JWTUtil.getUsername(principals.toString());
+        UserBean user = userService.getUser(username);
+        SimpleAuthorizationInfo simpleAuthorizationInfo = new SimpleAuthorizationInfo();
+        simpleAuthorizationInfo.addRole(user.getRole());
+        Set<String> permission = new HashSet<>(Arrays.asList(user.getPermission().split(",")));
+        simpleAuthorizationInfo.addStringPermissions(permission);
+        return simpleAuthorizationInfo;
+    }
+
+    /**
+     * 默认使用此方法进行用户名正确与否验证，错误抛出异常即可。
+     */
+    @Override
+    protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken auth) throws AuthenticationException {
+        String token = (String) auth.getCredentials();
+        // 解密获得username，用于和数据库进行对比
+        String username = JWTUtil.getUsername(token);
+        if (username == null) {
+            throw new AuthenticationException("token invalid");
+        }
+
+        UserBean userBean = userService.getUser(username);
+        if (userBean == null) {
+            throw new AuthenticationException("User didn't existed!");
+        }
+
+        if (! JWTUtil.verify(token, username, userBean.getPassword())) {
+            throw new AuthenticationException("Username or password error");
+        }
+
+        return new SimpleAuthenticationInfo(token, token, "my_realm");
+    }
+}

--- a/src/main/java/com/backend/seqaq/service/UsersService.java
+++ b/src/main/java/com/backend/seqaq/service/UsersService.java
@@ -1,5 +1,6 @@
 package com.backend.seqaq.service;
 
+import com.backend.seqaq.entity.UserBean;
 import com.backend.seqaq.entity.Users;
 import com.backend.seqaq.util.exception.RegistrationException;
 
@@ -19,4 +20,6 @@ public interface UsersService {
   String checkStatus(String account);
 
   void activate(Users user);
+
+  UserBean getUser(String username);
 }

--- a/src/main/java/com/backend/seqaq/service/impl/UsersServiceImpl.java
+++ b/src/main/java/com/backend/seqaq/service/impl/UsersServiceImpl.java
@@ -28,6 +28,7 @@ public class UsersServiceImpl implements UsersService {
     if (users == null) return "Error";
     else {
       users.setStatus(0);
+      usersDao.saveUser(users);
       return "OK";
     }
   }
@@ -37,6 +38,7 @@ public class UsersServiceImpl implements UsersService {
     if (users == null) return "Error";
     else {
       users.setStatus(1);
+      usersDao.saveUser(users);
       return "OK";
     }
   }

--- a/src/main/java/com/backend/seqaq/service/impl/UsersServiceImpl.java
+++ b/src/main/java/com/backend/seqaq/service/impl/UsersServiceImpl.java
@@ -1,6 +1,7 @@
 package com.backend.seqaq.service.impl;
 
 import com.backend.seqaq.dao.UsersDao;
+import com.backend.seqaq.entity.UserBean;
 import com.backend.seqaq.entity.Users;
 import com.backend.seqaq.service.UsersService;
 import com.backend.seqaq.util.exception.RegistrationException;
@@ -78,5 +79,21 @@ public class UsersServiceImpl implements UsersService {
   public void activate(Users user) {
     user.setStatus(Users.STAT_ACTIVATED);
     usersDao.saveUser(user);
+  }
+
+  @Override
+  public UserBean getUser(String username) {
+    Users users = usersDao.findByAccount(username);
+    if (users == null) {
+      return null;
+    }
+
+    UserBean user = new UserBean();
+    user.setUsername(username);
+    user.setPassword(users.getPassword());
+    user.setRole(users.getRole());
+    user.setPermission(users.getPermission());
+
+    return user;
   }
 }


### PR DESCRIPTION
完整实现了shiro + jwt的登录认证功能

为controller接口提供了标签形式的身份认证与权限管理

需要登录后使用的添加：**@RequiresAuthentication**

需要管理员身份的添加：**@RequiresRoles("admin")**

更新了数据库，添加了permission字段，类型为 varchar(50) 用于精细划分权限

权限之间用 "," 进行分隔，详见数据导入脚本中的例子

使用时作为标签添加，与管理员身份认证类似：

如需要同时拥有浏览、编辑权限：**@RequiresPermissions(logical = Logical.AND, value = {"view", "edit"})**